### PR TITLE
Migrate Homebrew formula to cask

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -29,7 +29,7 @@ builds:
       - goos: windows
         goarch: arm64
 
-brews:
+homebrew_casks:
   - name: eatme
     repository:
       owner: kulapard
@@ -39,13 +39,16 @@ brews:
     commit_author:
       name: Taras Drapalyuk
       email: taras@drapalyuk.com
-    commit_msg_template: "Brew formula update for `{{ .ProjectName }}` version `{{ .Tag }}`"
-    directory: Formula
+    commit_msg_template: "Brew cask update for `{{ .ProjectName }}` version `{{ .Tag }}`"
     homepage: "https://github.com/kulapard/go-eatme"
     description: "Simple tool to manage multiple git/hg repositories at once. It goes through all subdirectories recursively and concurrently execute specified command in all af them."
     license: "MIT"
-    test: |
-      system "#{bin}/eatme branch"
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/eatme"]
+          end
 
 archives:
   - formats: [ 'tar.gz' ]

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ concurrently execute specified command in all af them.
 Using [Homebrew](http://brew.sh/) (OS X / Linux)
 
 ```shell
-brew install kulapard/tap/eatme
+brew install --cask kulapard/tap/eatme
 ```
 
 ## Update ##


### PR DESCRIPTION
## What

Migrate Homebrew distribution from a **formula** to a **cask**, per goreleaser deprecation (`brews` deprecated v2.10, hard-deprecated v2.16, removal upcoming).

## Why

goreleaser ships pre-compiled binaries. Homebrew now recommends **casks** for pre-built binaries; formulae are meant for source builds. Casks also handle macOS Gatekeeper quarantine for unsigned binaries.

## Changes

- `.goreleaser.yaml`: `brews:` → `homebrew_casks:`
- Drop `directory: Formula` (casks default to `Casks/`)
- Drop formula-only `test:` stanza
- Add post-install hook stripping `com.apple.quarantine` so the unsigned macOS binary runs without a Gatekeeper block
- `README.md`: `brew install` → `brew install --cask`

Validated with `goreleaser check` — clean, deprecation warning gone.

## Follow-up (separate repo: `kulapard/homebrew-tap`)

After this merges and **release v0.1.38 is cut** (so goreleaser writes `Casks/eatme.rb`):

1. Add `tap_migrations.json` → `{ "eatme": "kulapard/tap" }`
2. `git rm Formula/eatme.rb`

This auto-migrates existing formula users to the cask on their next `brew upgrade`. Order matters — cask must exist in the tap before the formula is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)